### PR TITLE
Make visualizer's bars unclickable

### DIFF
--- a/visualizerCSS.css
+++ b/visualizerCSS.css
@@ -87,6 +87,7 @@ put css in here to reduce the amout of dom manipulation in the js file
     background-color: #ffffff;
     z-index: 1502;
     opacity: 0.8;
+    pointer-events: none;
 }
 
 #canvas1{


### PR DESCRIPTION
I add `pointer-events: none;` to visualizer's bars to prevent clicking event trigger, so that users can click through the visualizer's bars.